### PR TITLE
Refactores the `postgres_container_with_data` test fixture to use a Q…

### DIFF
--- a/src/quackpipe/test_utils/postgres_fixtures.py
+++ b/src/quackpipe/test_utils/postgres_fixtures.py
@@ -1,8 +1,10 @@
 import logging
+from collections.abc import Generator
+from typing import Any
 
 import pandas as pd
 import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 from testcontainers.postgres import PostgresContainer
 
 from quackpipe import QuackpipeBuilder, SourceType
@@ -15,9 +17,11 @@ from quackpipe.test_utils.data_generators import (
 
 logger = logging.getLogger(__name__)
 
+POSTGRES_SOURCE_NAME = "pg_source"
+
 
 @pytest.fixture(scope="module")
-def postgres_container():
+def postgres_container() -> Generator[PostgresContainer, Any, None]:
     container = PostgresContainer("postgres:15-alpine")
     container.with_env("POSTGRES_USER", "test")
     container.with_env("POSTGRES_PASSWORD", "test")
@@ -34,64 +38,49 @@ def postgres_engine(postgres_container):
 
 
 @pytest.fixture(scope="module")
-def postgres_container_with_data(postgres_container, postgres_engine):
+def postgres_container_with_data(postgres_container, quackpipe_with_pg_source) -> PostgresContainer:
     """
-    Starts a PostgreSQL container with sample data for testing.
-    Creates tables and populates them with synthetic data.
+    Starts a PostgreSQL container and populates it with sample data for testing
+    using a temporary Quackpipe connection.
     """
 
     employee_data = create_employee_data()
     monthly_data = create_monthly_data()
     vessels = create_vessel_definitions()
 
-    # Create DataFrames
     employees_df = pd.DataFrame(employee_data)
     monthly_df = pd.DataFrame(monthly_data)
+    vessels_df = pd.DataFrame(vessels)
     synthetic_ais_df = generate_synthetic_ais_data(vessels)
+    synthetic_ais_df['BaseDateTime'] = pd.to_datetime(synthetic_ais_df['BaseDateTime'])
+    synthetic_ais_df.columns = synthetic_ais_df.columns.str.lower()
 
-    # Create tables and insert data
-    with postgres_engine.connect() as conn:
-        conn.execute(text("CREATE SCHEMA company"))
-        # Create and populate employees table
-        employees_df.to_sql('employees', conn, schema='company', if_exists='replace', index=False)
+    with quackpipe_with_pg_source.session() as con:
+        con.execute(f"CREATE SCHEMA IF NOT EXISTS {POSTGRES_SOURCE_NAME}.company;")
+        con.execute(f"CREATE TABLE {POSTGRES_SOURCE_NAME}.company.employees AS SELECT * FROM employees_df;")
+        con.execute(f"CREATE TABLE {POSTGRES_SOURCE_NAME}.company.monthly_reports AS SELECT * FROM monthly_df;")
+        con.execute(f"CREATE TABLE {POSTGRES_SOURCE_NAME}.vessels AS SELECT * FROM vessels_df;")
+        con.execute(f"CREATE TABLE {POSTGRES_SOURCE_NAME}.ais_data AS SELECT * FROM synthetic_ais_df;")
 
-        # Create and populate monthly_reports table
-        monthly_df.to_sql('monthly_reports', conn, schema='company', if_exists='replace', index=False)
+        con.execute(f"CREATE INDEX idx_employees_department ON {POSTGRES_SOURCE_NAME}.company.employees(department);")
+        con.execute(f"CREATE INDEX idx_ais_mmsi ON {POSTGRES_SOURCE_NAME}.ais_data(mmsi);")
+        con.execute(f"CREATE INDEX idx_ais_datetime ON {POSTGRES_SOURCE_NAME}.ais_data(basedatetime);")
+        con.execute(f"CREATE INDEX idx_vessels_mmsi ON {POSTGRES_SOURCE_NAME}.vessels(mmsi);")
 
-        # Create and populate vessels table (from vessel definitions)
-        vessels_df = pd.DataFrame(vessels)
-        vessels_df.to_sql('vessels', conn, if_exists='replace', index=False)
+        # Use postgres_execute to create the view directly in PostgreSQL
+        create_view_sql = """
+            CREATE VIEW ais_with_vessel_info AS
+            SELECT a.*,
+                   v.name   as vessel_name_from_vessels,
+                   v.type   as vessel_type_from_vessels,
+                   v.length as vessel_length_from_vessels,
+                   v.width  as vessel_width_from_vessels
+            FROM ais_data a
+            LEFT JOIN vessels v ON a.mmsi = v.mmsi;
+        """
+        con.execute(f"CALL postgres_execute('{POSTGRES_SOURCE_NAME}', '{create_view_sql.replace('\'', '''''')}')")
 
-        # Create and populate AIS data table
-        # Note: Converting BaseDateTime to proper datetime for PostgreSQL
-        ais_df_pg = synthetic_ais_df.copy()
-        ais_df_pg['BaseDateTime'] = pd.to_datetime(ais_df_pg['BaseDateTime'])
-
-        # Convert column names to lowercase for PostgreSQL
-        ais_df_pg.columns = ais_df_pg.columns.str.lower()
-        ais_df_pg.to_sql('ais_data', conn, if_exists='replace', index=False)
-
-        # Create some indexes for better query performance
-        conn.execute(text("CREATE INDEX idx_employees_department ON company.employees(department)"))
-        conn.execute(text("CREATE INDEX idx_ais_mmsi ON ais_data(mmsi)"))
-        conn.execute(text("CREATE INDEX idx_ais_datetime ON ais_data(basedatetime)"))
-        conn.execute(text("CREATE INDEX idx_vessels_mmsi ON vessels(mmsi)"))
-
-        # Create a view that joins AIS data with vessel information
-        conn.execute(text("""
-                          CREATE VIEW ais_with_vessel_info AS
-                          SELECT a.*,
-                                 v.name   as vessel_name_from_vessels,
-                                 v.type   as vessel_type_from_vessels,
-                                 v.length as vessel_length_from_vessels,
-                                 v.width  as vessel_width_from_vessels
-                          FROM ais_data a
-                                   LEFT JOIN vessels v ON a.mmsi = v.mmsi
-                          """))
-
-        conn.commit()
-
-    logger.info("PostgreSQL container populated with:")
+    logger.info("PostgreSQL container populated via Quackpipe with:")
     logger.info(f"  - {len(employees_df)} employee records")
     logger.info(f"  - {len(monthly_df)} monthly report records")
     logger.info(f"  - {len(vessels_df)} vessel definitions")
@@ -102,19 +91,21 @@ def postgres_container_with_data(postgres_container, postgres_engine):
 
 
 @pytest.fixture(scope="module")
-def quackpipe_with_pg_source(postgres_container_with_data) -> QuackpipeBuilder:
+def quackpipe_with_pg_source(postgres_container) -> QuackpipeBuilder:
+    """
+    Provides a Quackpipe builder with a read-write connection to the PostgreSQL source.
+    """
     builder = QuackpipeBuilder().add_source(
-        name="pg_source",
+        name=POSTGRES_SOURCE_NAME,
         type=SourceType.POSTGRES,
         config={
             'database': 'test',
             'user': 'test',
             'password': 'test',
-            'host': postgres_container_with_data.get_container_host_ip(),
-            'port': postgres_container_with_data.get_exposed_port(5432),
+            'host': postgres_container.get_container_host_ip(),
+            'port': postgres_container.get_exposed_port(5432),
             'connection_name': 'pg_main',
-            'read_only': True,
-            'tables': ['company.employees', 'company.monthly_reports', 'vessels']
+            'read_only': False
         }
     )
     return builder

--- a/tests/test_e2e_ducklake_integration.py
+++ b/tests/test_e2e_ducklake_integration.py
@@ -1,16 +1,11 @@
 """
-tests/test_e2e_ducklake_integration.py
-
 This file contains true end-to-end integration tests using testcontainers
 to spin up real services like PostgreSQL and MinIO in Docker.
 
 NOTE: To run these tests, you must have Docker installed and running.
-You will also need to install the required test dependencies.
-
-Installation command:
-pip install "quackpipe[test]" "testcontainers-postgres>=3.7.0" "testcontainers-minio>=2.3.1" "httpx>=0.23.0"
 """
 import pandas as pd
+from testcontainers.postgres import PostgresContainer
 
 from quackpipe import QuackpipeBuilder, SourceConfig
 from quackpipe.etl_utils import move_data
@@ -20,6 +15,7 @@ from quackpipe.etl_utils import move_data
 def test_e2e_postgres_to_ducklake(
         quackpipe_with_pg_source: QuackpipeBuilder,
         postgres_s3_ducklake_config: SourceConfig,
+        postgres_container_with_data: PostgresContainer,  # this will generate the data inside postgres
         test_datasets: dict
 ):
     """
@@ -35,6 +31,7 @@ def test_e2e_postgres_to_ducklake(
 
     # Move data from the pre-populated Postgres source to the DuckLake destination
     # Move the 'employees' table
+    # the name of the source 'pg_source' should match the value of POSTGRES_SOURCE_NAME in the fixtures
     print("Moving 'employees' table to DuckLake...")
     move_data(
         configs=builder.get_configs(),

--- a/tests/test_postgres_handler.py
+++ b/tests/test_postgres_handler.py
@@ -159,16 +159,11 @@ def test_postgres_handler_no_tables():
     assert "CREATE OR REPLACE VIEW" not in sql
 
 
-def test_integration_with_postgres_e2e(quackpipe_with_pg_source):
+def test_integration_with_postgres_e2e(quackpipe_with_pg_source, postgres_container_with_data):
     with quackpipe_with_pg_source.session() as con:
+        # the name of the source 'pg_source' should match the value of POSTGRES_SOURCE_NAME in the fixtures
         results = con.execute(
             "FROM pg_source.company.employees"
-        ).fetchall()
-        assert len(results) == 5
-
-        # check the view
-        results = con.execute(
-            "FROM pg_source_company_employees"
         ).fetchall()
         assert len(results) == 5
 
@@ -180,8 +175,4 @@ def test_integration_with_postgres_e2e(quackpipe_with_pg_source):
         assert results[1][1] == "Diana"
 
         results = con.execute('FROM pg_source.vessels').fetchall()
-        assert len(results) == 5
-
-        # check the view
-        results = con.execute("FROM pg_source_vessels").fetchall()
         assert len(results) == 5


### PR DESCRIPTION
…uackpipe/DuckDB connection for data loading instead of SQLAlchemy and pandas.to_sql.

This change introduces a clean separation of concerns:
- `postgres_container_with_data` is now responsible for populating the test database. It uses the quackpipe_with_pg_source fixture to load the data.
- `quackpipe_with_pg_source` provides a connection to the container. If `postgres_container_with_data` is also used on a test, then this connection will provide access to that data.