### PR TITLE
Refactor session to be a flexible connection factory

### DIFF
--- a/src/quackpipe/core.py
+++ b/src/quackpipe/core.py
@@ -82,15 +82,27 @@ def _prepare_connection(con: duckdb.DuckDBPyConnection, configs: list[SourceConf
             raise
 
 
-@contextmanager
 def session(
         config_path: str | None = None,
         configs: list[SourceConfig] | None = None,
         sources: list[str] | None = None,
         env_file: str | None = None
-) -> Generator[duckdb.DuckDBPyConnection, None, None]:
+) -> duckdb.DuckDBPyConnection:
     """
-    A context manager providing a pre-configured DuckDB connection.
+    Creates and returns a pre-configured DuckDB connection.
+
+    The returned connection object is a context manager and can be used in a
+    `with` statement, which will automatically handle closing the connection.
+
+    Example:
+        # As a context manager
+        with session(config_path="config.yml") as con:
+            con.sql("SELECT * FROM my_table")
+
+        # As a direct function call
+        con = session(config_path="config.yml")
+        # Remember to close it yourself
+        con.close()
     """
     configure_secret_provider(env_file=env_file)
 
@@ -101,11 +113,8 @@ def session(
         active_configs = [c for c in all_configs if c.name in sources]
 
     con = duckdb.connect(database=':memory:')
-    try:
-        _prepare_connection(con, active_configs)
-        yield con
-    finally:
-        con.close()
+    _prepare_connection(con, active_configs)
+    return con
 
 
 def with_session(**session_kwargs):

--- a/src/quackpipe/test_utils/fixtures.py
+++ b/src/quackpipe/test_utils/fixtures.py
@@ -1,8 +1,9 @@
 import logging
 import os
 import tempfile
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
+import duckdb
 import pandas as pd
 import pytest
 import yaml
@@ -73,16 +74,22 @@ def sample_yaml_config(temp_dir, sample_config_dict):
 @pytest.fixture
 def mock_duckdb_connection():
     """Mock DuckDB connection for testing."""
-    mock_con = Mock()
-    mock_con.execute = Mock()
-    mock_con.install_extension = Mock()
-    mock_con.load_extension = Mock()
-    mock_con.close = Mock()
+    mock_con = MagicMock(spec=duckdb.DuckDBPyConnection)
 
-    # Mock fetchdf for pandas integration
-    mock_result = Mock()
-    mock_result.fetchdf.return_value = pd.DataFrame({'id': [1, 2], 'name': ['Alice', 'Bob']})
+    # Mock fetch_df for pandas integration
+    mock_result = MagicMock()
+    mock_result.fetch_df.return_value = pd.DataFrame({'id': [1, 2], 'name': ['Alice', 'Bob']})
     mock_con.execute.return_value = mock_result
+
+    # When the mock is used as a context manager, __enter__ should return the mock itself.
+    mock_con.__enter__.return_value = mock_con
+
+    # The real duckdb connection calls .close() when the context manager exits.
+    # We need to replicate this behavior in the mock.
+    def exit_side_effect(*args, **kwargs):
+        mock_con.close()
+
+    mock_con.__exit__.side_effect = exit_side_effect
 
     return mock_con
 

--- a/tests/test_etl_utils.py
+++ b/tests/test_etl_utils.py
@@ -205,6 +205,7 @@ def test_full_workflow_builder_api(mock_configure_secrets, mock_connect, mock_du
 
     # Act
     with builder.session() as con:
+        con.execute.return_value.fetch_df.return_value = pd.DataFrame([{"id": 1}])
         df = to_df(con, "SELECT * FROM pg_test_users")
         assert isinstance(df, pd.DataFrame)
 

--- a/tests/test_quackpipe.py
+++ b/tests/test_quackpipe.py
@@ -308,6 +308,27 @@ def test_session_with_sources_filter(mock_prepare, mock_connect, mock_duckdb_con
     assert {c.name for c in prepared_configs} == {"pg1", "s3_1"}
 
 
+@patch('duckdb.connect')
+@patch('quackpipe.core._prepare_connection')
+def test_session_as_function(mock_prepare, mock_connect, mock_duckdb_connection):
+    """Test session creation as a direct function call."""
+    mock_connect.return_value = mock_duckdb_connection
+
+    # Call session as a regular function
+    con = session(configs=[SourceConfig(name="test", type=SourceType.POSTGRES)])
+
+    # Assert that a connection was returned
+    assert con is mock_duckdb_connection
+
+    # Assert that prepare was called, but close was NOT
+    mock_prepare.assert_called_once()
+    mock_duckdb_connection.close.assert_not_called()
+
+    # Now, manually close and check
+    con.close()
+    mock_duckdb_connection.close.assert_called_once()
+
+
 # ==================== ERROR HANDLING TESTS ====================
 
 def test_config_error_inheritance():


### PR DESCRIPTION
The `session` function in `core.py` has been refactored to remove the `@contextmanager` decorator. It now directly returns a `duckdb.DuckDBPyConnection` object.

This change provides greater flexibility for users:
- The `session` function can still be used as a context manager (`with session(...) as con:`), as the returned connection object supports the context manager protocol and handles its own closing.
- It can also be called as a regular function (`con = session(...)`), giving the user direct control over the connection's lifecycle.

The test suite has been updated to validate both usage patterns. The `mock_duckdb_connection` fixture has been improved to more accurately mimic the behavior of a real connection object, including its context management.