### PR TITLE
feat: Allow config path to be specified via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ pip install "quackpipe[postgres,s3,azure,ui]"
 
 `quackpipe` uses a simple `config.yml` file to define your sources and an `.env` file to manage your secrets.
 
+### Configuration Priority
+
+Quackpipe loads its configuration in the following order of priority:
+
+1.  **Directly in code:** You can pass a `config_path` or a list of `configs` directly to functions like `quackpipe.session()` or `move_data()`. This always takes the highest priority.
+2.  **Environment Variable:** If no configuration is provided in code, Quackpipe will check for the `QUACKPIPE_CONFIG_PATH` environment variable. You can set this to the path of your `config.yml` file.
+3.  **Local `config.yml`:** When using the CLI, if a `config.yml` file exists in the current directory, it will be used automatically.
+
+This layered approach provides flexibility for both interactive use and production deployments.
+
 ### `config.yml` Example
 
 ```yaml

--- a/src/quackpipe/commands/common.py
+++ b/src/quackpipe/commands/common.py
@@ -4,7 +4,20 @@ src/quackpipe/commands/common.py
 This module contains common utilities shared across CLI command modules.
 """
 import logging
+import os
 import sys
+
+DEFAULT_CONFIG_NAME = "config.yml"
+
+
+def get_default_config_path():
+    """
+    Returns 'config.yml' if it exists in the current directory, otherwise None.
+    This allows for a dynamic default value in the CLI.
+    """
+    if os.path.exists(DEFAULT_CONFIG_NAME):
+        return DEFAULT_CONFIG_NAME
+    return None
 
 
 def setup_cli_logging(verbose_level: int = 0):

--- a/src/quackpipe/commands/generate_sqlmesh_config.py
+++ b/src/quackpipe/commands/generate_sqlmesh_config.py
@@ -11,6 +11,7 @@ from ..config import SourceConfig
 from ..core import SOURCE_HANDLER_REGISTRY
 from ..secrets import configure_secret_provider, fetch_raw_secret_bundle
 from ..utils import get_configs
+from .common import get_default_config_path
 
 
 def _generate_raw_sql(configs: list[SourceConfig]) -> str:
@@ -72,8 +73,10 @@ def register_command(subparsers: _SubParsersAction):
         "generate-sqlmesh-config",
         help="Generate a SQLMesh config file from a quackpipe config."
     )
-    parser_gen.add_argument("-c", "--config", default="config.yml",
-                            help="Path to the input quackpipe config.yml file. (Default: config.yml)")
+    parser_gen.add_argument("-c", "--config", default=get_default_config_path(),
+                            help="Path to the quackpipe config.yml file. Defaults to 'config.yml' in the current "
+                                 "directory if it exists or else it will check the "
+                                 "QUACKPIPE_CONFIG_PATH environment variable.")
     parser_gen.add_argument("-o", "--output", default="sqlmesh_config.yml",
                             help="Path for the output SQLMesh config file. (Default: sqlmesh_config.yml)")
     parser_gen.add_argument("--gateway-name", default="quackpipe_gateway",

--- a/src/quackpipe/commands/ui.py
+++ b/src/quackpipe/commands/ui.py
@@ -7,7 +7,7 @@ from argparse import _SubParsersAction
 
 from .. import ConfigError
 from ..core import session
-from .common import setup_cli_logging
+from .common import get_default_config_path, setup_cli_logging
 
 
 def handler(args):
@@ -58,11 +58,14 @@ def register_command(subparsers: _SubParsersAction):
         "ui",
         help="Launch an interactive DuckDB UI with pre-configured sources."
     )
-    parser_ui.add_argument("-c", "--config", default="config.yml",
-                           help="Path to the input quackpipe config.yml file. (Default: config.yml)")
+    parser_ui.add_argument("-c", "--config", default=get_default_config_path(),
+                            help="Path to the quackpipe config.yml file. Defaults to 'config.yml' in the current "
+                                 "directory if it exists or else it will check the "
+                                 "QUACKPIPE_CONFIG_PATH environment variable.")
     parser_ui.add_argument("--env-file", default=".env",
                            help="Path to the environment file to load secrets from. (Default: .env)")
-    parser_ui.add_argument("-p", "--port", type=int, default=4213, help="Port to run the DuckDB UI on. (Default: 4213)")
+    parser_ui.add_argument("-p", "--port", type=int, default=4213,
+                           help="Port to run the DuckDB UI on. (Default: 4213)")
     parser_ui.add_argument(
         "-v", "--verbose",
         action="count",
@@ -70,5 +73,6 @@ def register_command(subparsers: _SubParsersAction):
         help="Increase output verbosity. Use -v for INFO and -vv for DEBUG."
     )
     parser_ui.add_argument("sources", nargs='*',
-                           help="Optional: A space-separated list of specific sources to load. If omitted, all sources are loaded.")
+                           help="Optional: A space-separated list of specific sources to load. "
+                                "If omitted, all sources are loaded.")
     parser_ui.set_defaults(func=handler)

--- a/src/quackpipe/core.py
+++ b/src/quackpipe/core.py
@@ -92,6 +92,10 @@ def session(
     The returned connection object is a context manager and can be used in a
     `with` statement, which will automatically handle closing the connection.
 
+    Configuration can be provided via the `config_path` parameter, the
+    `QUACKPIPE_CONFIG_PATH` environment variable, or by passing a list of
+    `SourceConfig` objects to the `configs` parameter.
+
     Example:
         # As a context manager
         with session(config_path="config.yml") as con:

--- a/src/quackpipe/etl_utils.py
+++ b/src/quackpipe/etl_utils.py
@@ -43,7 +43,8 @@ def move_data(
         source_query: The SELECT query to execute for the source data.
         destination_name: The logical name of the destination source from the config.
         table_name: The name of the table or file to create at the destination.
-        config_path: Path to the YAML configuration file.
+        config_path: Path to the YAML configuration file. Can also be set via the
+            `QUACKPIPE_CONFIG_PATH` environment variable.
         configs: A direct list of SourceConfig objects.
         env_file: Path to an env file to use.
         mode: Write mode. 'replace' or 'append'.

--- a/src/quackpipe/utils.py
+++ b/src/quackpipe/utils.py
@@ -1,6 +1,7 @@
 """
 General utility functions for the quackpipe library.
 """
+import os
 
 import yaml
 from duckdb import ConnectionException, DuckDBPyConnection
@@ -48,16 +49,28 @@ def get_configs(
         configs: list[SourceConfig] | None = None
 ) -> list[SourceConfig]:
     """
-    A helper function to load source configurations from either a file path or a direct list.
+    A helper function to load source configurations. The priority is:
+    1. A file path from the `config_path` argument.
+    2. A direct list from the `configs` argument.
+    3. A file path from the `QUACKPIPE_CONFIG_PATH` environment variable.
+
     This logic is shared by `session` and `etl_utils`.
     """
     if config_path:
         return parse_config_from_yaml(config_path)
     elif configs:
         return configs
+
+    # As a last resort, try the environment variable.
+    env_config_path = os.environ.get("QUACKPIPE_CONFIG_PATH")
+    if env_config_path:
+        return parse_config_from_yaml(env_config_path)
     else:
         # This provides a clear error message if no configuration source is given.
-        raise ConfigError("Must provide either a 'config_path' or a 'configs' list.")
+        raise ConfigError(
+            "Must provide either a 'config_path', a 'configs' list, or set the "
+            "'QUACKPIPE_CONFIG_PATH' environment variable."
+        )
 
 
 def is_connection_open(conn: DuckDBPyConnection) -> bool:

--- a/tests/test_quackpipe.py
+++ b/tests/test_quackpipe.py
@@ -247,6 +247,19 @@ def test_session_with_config_path(mock_prepare, sample_yaml_config):
     assert not is_connection_open(con)
 
 
+@patch('quackpipe.core._prepare_connection')
+def test_session_with_env_var(mock_prepare, sample_yaml_config, monkeypatch):
+    """Test session creation with environment variable."""
+    monkeypatch.setenv("QUACKPIPE_CONFIG_PATH", sample_yaml_config)
+
+    with session() as con:
+        assert type(con) is DuckDBPyConnection
+        assert is_connection_open(con)
+
+    mock_prepare.assert_called_once()
+    assert not is_connection_open(con)
+
+
 @patch('duckdb.connect')
 def test_session_with_configs(mock_connect, mock_duckdb_connection, monkeypatch):
     """Test session creation with direct configs."""
@@ -281,9 +294,30 @@ def test_session_with_configs(mock_connect, mock_duckdb_connection, monkeypatch)
 
 def test_session_no_config():
     """Test session creation without config."""
-    with pytest.raises(ConfigError, match="Must provide either a 'config_path' or a 'configs'"):
+    with pytest.raises(ConfigError, match="Must provide either a 'config_path', a 'configs' list, or set the 'QUACKPIPE_CONFIG_PATH' environment variable."):
         with session():
             pass
+
+
+@patch('quackpipe.core._prepare_connection')
+def test_session_prioritizes_configs_over_env_var(mock_prepare, sample_yaml_config, monkeypatch):
+    """Test that direct configs are prioritized over the environment variable."""
+    # Set the env var to a valid config
+    monkeypatch.setenv("QUACKPIPE_CONFIG_PATH", sample_yaml_config)
+
+    # Provide a different, direct config
+    direct_configs = [SourceConfig(name="direct_config", type=SourceType.SQLITE)]
+
+    with session(configs=direct_configs):
+        pass
+
+    # The call to _prepare_connection should have used the direct_configs
+    mock_prepare.assert_called_once()
+    call_args = mock_prepare.call_args[0]
+    prepared_configs = call_args[1]
+
+    assert len(prepared_configs) == 1
+    assert prepared_configs[0].name == "direct_config"
 
 
 @patch('duckdb.connect')


### PR DESCRIPTION
This commit introduces the ability to specify the quackpipe configuration file path using the `QUACKPIPE_CONFIG_PATH` environment variable.

The changes include:
- Modifying the `get_configs` utility function to check for the `QUACKPIPE_CONFIG_PATH` environment variable if no `config_path` is provided.
- Updating the CLI commands (`ui` and `generate-sqlmesh-config`) to make the `--config` argument optional. If not provided, the application will fall back to the environment variable.
- Updating docstrings for the `session` and `move_data` functions to reflect the new configuration option.
- Adding a new test case to verify that the configuration is loaded from the environment variable.
- Updating an existing test case to match the new error message when no configuration is found.